### PR TITLE
fix: resolve runtime crash in financial runway graph

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -283,12 +283,12 @@
 
         // Monthly gap (using the same current-age effective cashflow rules as the runway scenario)
         const effectiveMonthlyIncome = monthlyIncome + (
-          socialSecurity.amount > 0 && age >= socialSecurity.startsAtAge
-            ? socialSecurity.amount
+          socialSecurity && socialSecurity.monthlyAmount > 0 && age >= socialSecurity.startsAtAge
+            ? socialSecurity.monthlyAmount
             : 0
         );
         const effectiveMonthlyExpenses = monthlyExpenses + (
-          healthcareGap.monthlyCost > 0 && age < healthcareGap.coveredUntilAge
+          healthcareGap && healthcareGap.monthlyCost > 0 && age < healthcareGap.coveredUntilAge
             ? healthcareGap.monthlyCost
             : 0
         );


### PR DESCRIPTION
- Add null guards for socialSecurity and healthcareGap before accessing their properties in the monthly-gap calculation
- Fix wrong property name: socialSecurity.amount -> socialSecurity.monthlyAmount

Both objects are null when their sliders are at zero (the default), causing a TypeError that aborted update() before drawChart() was called.